### PR TITLE
chore(ci): add Dependabot to charts-docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/docs-app"
+    schedule:
+      interval: "monthly"
+    groups:
+      docs-app-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- add Dependabot configuration for `charts-docs`
- enable monthly updates for:
  - GitHub Actions
  - npm dependencies in `docs-app`
- group npm updates under `docs-app-dependencies`
