### PR TITLE
Use version helpers for docs API/demo links

### DIFF
--- a/docs-app/app/[version]/api/page.tsx
+++ b/docs-app/app/[version]/api/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { getAllVersions, getVersion } from '@/lib/versions';
+import { getVersionApiIndexUrl } from '@/lib/version-links';
 
 interface ApiPageProps {
   params: Promise<{ version: string }>;
@@ -21,8 +22,7 @@ export default async function ApiPage({ params }: ApiPageProps) {
     return <div>Version not found</div>;
   }
 
-  // The API docs are served from static assets
-  const apiUrl = `/static/api/${versionId}/index.html`;
+  const apiUrl = getVersionApiIndexUrl(version);
 
   return (
     <div className="docs-content animate-fadeIn" style={{ maxWidth: 'none' }}>

--- a/docs-app/app/[version]/layout.tsx
+++ b/docs-app/app/[version]/layout.tsx
@@ -24,7 +24,7 @@ export default async function VersionLayout({ children, params }: VersionLayoutP
   return (
     <div className="docs-layout">
       <Header versions={versions} currentVersion={version} />
-      <Sidebar navigation={navigation} versionId={versionId} />
+      <Sidebar navigation={navigation} version={version} />
       <main className="docs-main">
         {children}
       </main>

--- a/docs-app/components/Sidebar.tsx
+++ b/docs-app/components/Sidebar.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { NavItem } from '@/lib/types';
+import { DocVersion, NavItem } from '@/lib/types';
+import { getVersionDemoUrl } from '@/lib/version-links';
 import {
   ApiReferenceIcon,
   DemoGalleryIcon,
@@ -17,7 +18,7 @@ import {
 
 interface SidebarProps {
   navigation: NavItem[];
-  versionId: string;
+  version: DocVersion;
 }
 
 function sanitizeNavigationPath(rawPath: string): string {
@@ -55,11 +56,12 @@ function getDocumentationIcon(slug: string) {
   }
 }
 
-export function Sidebar({ navigation, versionId }: SidebarProps) {
+export function Sidebar({ navigation, version }: SidebarProps) {
   const pathname = usePathname();
   const [hash, setHash] = useState('');
   const [mobileNavPath, setMobileNavPath] = useState<string | null>(null);
   const isMobileNavOpen = mobileNavPath === pathname;
+  const demoUrl = getVersionDemoUrl(version);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -169,7 +171,7 @@ export function Sidebar({ navigation, versionId }: SidebarProps) {
           <div className="docs-sidebar__section-title">Resources</div>
           <nav className="docs-sidebar__nav">
             <Link
-              href={`/${versionId}/api`}
+              href={`/${version.id}/api`}
               className={`docs-sidebar__link ${pathname.includes('/api') ? 'docs-sidebar__link--active' : ''}`}
               onClick={closeMobileNavigation}
             >
@@ -177,7 +179,7 @@ export function Sidebar({ navigation, versionId }: SidebarProps) {
               API Reference
             </Link>
             <a
-              href={`/demo/${versionId}/`}
+              href={demoUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="docs-sidebar__link"

--- a/docs-app/lib/version-links.ts
+++ b/docs-app/lib/version-links.ts
@@ -1,0 +1,31 @@
+import { DocVersion } from './types';
+
+function appendPath(base: string, suffix: string): string {
+  const normalizedBase = base.replace(/\/+$/, '');
+  const normalizedSuffix = suffix.replace(/^\/+/, '');
+  return `${normalizedBase}/${normalizedSuffix}`;
+}
+
+function normalizeInternalOrAbsoluteUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+export function getVersionApiIndexUrl(version: DocVersion): string {
+  const apiBase = version.apiBase.trim() || `/static/api/${version.id}`;
+  return appendPath(apiBase, 'index.html');
+}
+
+export function getVersionDemoUrl(version: DocVersion): string {
+  const configuredUrl = normalizeInternalOrAbsoluteUrl(version.demoBase ?? '');
+  const demoBase = configuredUrl || `/demo/${version.id}/`;
+  return demoBase.endsWith('/') ? demoBase : `${demoBase}/`;
+}

--- a/scripts/test-docs-release-links-contract.sh
+++ b/scripts/test-docs-release-links-contract.sh
@@ -12,6 +12,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REGISTRY_PATH="${REPO_ROOT}/registry/versions.json"
 NEXT_CONFIG_PATH="${REPO_ROOT}/docs-app/next.config.ts"
 SIDEBAR_PATH="${REPO_ROOT}/docs-app/components/Sidebar.tsx"
+API_PAGE_PATH="${REPO_ROOT}/docs-app/app/[version]/api/page.tsx"
 
 failures=0
 
@@ -122,8 +123,10 @@ test_clean_link_routes_are_present() {
 }
 
 test_user_facing_links_use_clean_paths() {
-  assert_file_contains "${SIDEBAR_PATH}" 'href={`/demo/${versionId}/`}' "sidebar demo link uses clean URL"
+  assert_file_contains "${SIDEBAR_PATH}" 'href={demoUrl}' "sidebar demo link resolves via version registry URL"
+  assert_file_contains "${SIDEBAR_PATH}" 'const demoUrl = getVersionDemoUrl(version);' "sidebar uses version demoBase helper"
   assert_file_contains "${SIDEBAR_PATH}" 'href="/playground"' "sidebar playground link uses clean URL"
+  assert_file_contains "${API_PAGE_PATH}" 'const apiUrl = getVersionApiIndexUrl(version);' "api page uses version apiBase helper"
 }
 
 main() {


### PR DESCRIPTION
## Summary
- route docs API iframe/open-link URLs through a new version-links helper using apiBase
- route sidebar demo link through demoBase via the same helper module
- update version layout/sidebar props to pass the full DocVersion
- extend link-contract CI script to assert helper-based link wiring

## Validation
- ./scripts/test-docs-release-links-contract.sh
- DOCS_STATIC_BASE_URL=https://example.com npm run build (in docs-app)
