### PR TITLE
docs: update docs links to HDCharts org

### DIFF
--- a/content/snapshot/changes/363-api-compatibility-checks.md
+++ b/content/snapshot/changes/363-api-compatibility-checks.md
@@ -2,5 +2,5 @@
 
 - type: `feature`
 - module: `charts-core`
-- pr: `https://github.com/dautovicharis/charts/pull/363`
+- pr: `https://github.com/HDCharts/charts/pull/363`
 - release_note: `Added automated API compatibility checks to help prevent accidental breaking changes in future releases.`

--- a/content/snapshot/changes/365-release-compatibility-migration-docs.md
+++ b/content/snapshot/changes/365-release-compatibility-migration-docs.md
@@ -2,5 +2,5 @@
 
 - type: `feature`
 - module: `charts`
-- pr: `https://github.com/dautovicharis/charts/pull/365`
+- pr: `https://github.com/HDCharts/charts/pull/365`
 - release_note: `Docs now include a migration guide and clearer release highlights.`

--- a/docs-app/app/privacy-policy/page.tsx
+++ b/docs-app/app/privacy-policy/page.tsx
@@ -56,7 +56,7 @@ export default function PrivacyPolicyPage() {
       <p>
         If you have questions about this Privacy Policy, contact us via{' '}
         <a
-          href="https://github.com/dautovicharis/Charts/issues"
+          href="https://github.com/HDCharts/charts/issues"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/docs-app/components/Header.tsx
+++ b/docs-app/components/Header.tsx
@@ -30,7 +30,7 @@ export function Header({ versions, currentVersion }: HeaderProps) {
           </Link>
         ) : null}
         <a
-          href="https://github.com/dautovicharis/charts"
+          href="https://github.com/HDCharts/charts"
           className="docs-header__link docs-header__link--github"
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- update docs-app GitHub links to point to the org repository (HDCharts/charts)
- update snapshot changeset PR links to use the org repository
- keep old release docs untouched

## Files changed
- docs-app/components/Header.tsx
- docs-app/app/privacy-policy/page.tsx
- content/snapshot/changes/363-api-compatibility-checks.md
- content/snapshot/changes/365-release-compatibility-migration-docs.md