### PR TITLE
docs(snapshot): update breaking changes from 2.2.0 compatibility check

### DIFF
--- a/content/snapshot/breaking-changes.md
+++ b/content/snapshot/breaking-changes.md
@@ -22,6 +22,35 @@ val chartViewStyle = ChartViewDefaults.style(
 
 - Recommended: Prefer named arguments when calling style factory functions.
 
+## charts-bar
+
+### Do I need to update call sites?
+- No, if you call `BarChartDefaults.style(...)` with named arguments only.
+- Yes, if you pass `BarChartDefaults.style(...)` arguments positionally after `barColor`, or if you call internal `validateBarData(...)` directly.
+
+### What changed
+- `BarChartDefaults.style(...)` adds `barColors: List<Color> = emptyList()` immediately after `barColor`.
+- `validateBarData(...)` now accepts `colorsSize` to validate `barColors` length against data points.
+
+### Migration (only if required)
+```kotlin
+// Before
+val barStyle = BarChartDefaults.style(
+    MaterialTheme.colorScheme.primary,
+    0.4f,
+    10.dp,
+)
+
+// After
+val barStyle = BarChartDefaults.style(
+    barColor = MaterialTheme.colorScheme.primary,
+    barAlpha = 0.4f,
+    space = 10.dp,
+)
+```
+
+- Recommended: Use named arguments for `BarChartDefaults.style(...)` to stay resilient to future parameter additions.
+
 ## charts-pie
 
 ### Do I need to update call sites?


### PR DESCRIPTION
## Why
The snapshot migration page needs to match API compatibility results against the `2.2.0` release baseline so users get accurate upgrade guidance.

## Summary
This updates the snapshot breaking-changes document after rerunning release compatibility checks against `2.2.0`. It keeps the existing `charts-core` and `charts-pie` migration guidance and adds the missing `charts-bar` section. The new section explains when call-site changes are required and includes a concrete migration example for positional argument usage.

## Changes
- Updated `content/snapshot/breaking-changes.md`
- Added `charts-bar` breaking-change section
- Documented `BarChartDefaults.style(...)` parameter addition impact
- Documented internal `validateBarData(...)` signature change impact

## Release/Changeset
- Not required (technical/internal-only)

## Notes/Risk
- None
