### PR TITLE
docs(changeset): add snapshot note for charts PR #411

### DIFF
--- a/content/snapshot/changes/411-line-chart-drag-point-default-color.md
+++ b/content/snapshot/changes/411-line-chart-drag-point-default-color.md
@@ -1,0 +1,6 @@
+# PR Changeset
+
+- type: `fix`
+- module: `charts-line`
+- pr: `https://github.com/HDCharts/charts/pull/411`
+- release_note: `Fixes line chart drag-point default color handling and improves custom preview point visibility.`


### PR DESCRIPTION
## Why
Charts PR #411 includes user-visible line chart behavior updates and requires a snapshot changeset entry.

## Changes
- Add `content/snapshot/changes/411-line-chart-drag-point-default-color.md`

## Linked PR
- https://github.com/HDCharts/charts/pull/411
