### PR TITLE
docs: add agent prompt builder page and navigation

### DIFF
--- a/docs-app/app/[version]/agent/page.tsx
+++ b/docs-app/app/[version]/agent/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from 'next';
+import { getAllVersions } from '@/lib/versions';
+import { AgentPromptBuilder } from '@/components/AgentPromptBuilder';
+
+interface AgentPromptPageProps {
+  params: Promise<{ version: string }>;
+}
+
+export async function generateMetadata({ params }: AgentPromptPageProps): Promise<Metadata> {
+  const { version } = await params;
+  return {
+    title: `Agent Prompt Builder | Charts ${version}`,
+    description: `Generate guided AI prompts for integrating Charts ${version}`,
+  };
+}
+
+export default async function AgentPromptPage({ params }: AgentPromptPageProps) {
+  const { version } = await params;
+  return (
+    <div className="docs-content">
+      <AgentPromptBuilder versionId={version} />
+    </div>
+  );
+}
+
+export function generateStaticParams() {
+  return getAllVersions().map((v) => ({ version: v.id }));
+}

--- a/docs-app/app/globals.css
+++ b/docs-app/app/globals.css
@@ -869,6 +869,140 @@ body {
 }
 
 /* ===========================================
+   Agent Prompt Builder
+   =========================================== */
+
+.agent-builder__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin: var(--space-5) 0 var(--space-4);
+}
+
+.agent-builder__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.agent-builder__field label {
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.agent-builder__field select,
+.agent-builder__field textarea {
+  width: 100%;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  font: inherit;
+}
+
+.agent-builder__field select:focus,
+.agent-builder__field textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.agent-builder__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.agent-builder__chip {
+  border: 1px solid var(--border-subtle);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--text-secondary);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  font-size: 0.84rem;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.agent-builder__chip:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.agent-builder__chip--active {
+  border-color: var(--color-primary-light);
+  color: #eef2ff;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.52), rgba(6, 182, 212, 0.36));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.15),
+    0 0 0 2px rgba(99, 102, 241, 0.22);
+}
+
+.agent-builder__chip--disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.agent-builder__hint {
+  margin-top: var(--space-2);
+  margin-bottom: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.agent-builder__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.agent-builder__toggles label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.agent-builder__prompt {
+  background: var(--code-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+}
+
+.agent-builder__prompt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.agent-builder__prompt-header h2 {
+  margin: 0;
+  border: none;
+  padding: 0;
+  font-size: 1rem;
+}
+
+.agent-builder__prompt pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 480px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+/* ===========================================
    Responsive
    =========================================== */
 
@@ -952,6 +1086,10 @@ body {
     margin-left: 0;
     margin-top: 0;
     padding: var(--space-6) var(--space-4);
+  }
+
+  .agent-builder__grid {
+    grid-template-columns: 1fr;
   }
   
 }

--- a/docs-app/components/AgentPromptBuilder.tsx
+++ b/docs-app/components/AgentPromptBuilder.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type PlatformOption = 'KMP + Compose' | 'Android Compose' | 'Compose Multiplatform';
+type ScopeOption = 'Selected chart module' | 'Charts umbrella (all modules)';
+
+const CHART_OPTIONS = [
+  'Line Chart',
+  'Bar Chart',
+  'Pie Chart',
+  'Histogram Chart',
+  'Multi Line Chart',
+  'Stacked Bar Chart',
+  'Stacked Area Chart',
+  'Radar Chart',
+] as const;
+
+const PLATFORM_OPTIONS: PlatformOption[] = [
+  'KMP + Compose',
+  'Android Compose',
+  'Compose Multiplatform',
+];
+const SCOPE_OPTIONS: ScopeOption[] = [
+  'Selected chart module',
+  'Charts umbrella (all modules)',
+];
+const CHARTS_REPO_URL = 'https://github.com/HDCharts/charts';
+
+interface AgentPromptBuilderProps {
+  versionId: string;
+}
+
+export function AgentPromptBuilder({ versionId }: AgentPromptBuilderProps) {
+  const [platform, setPlatform] = useState<PlatformOption>('KMP + Compose');
+  const [scope, setScope] = useState<ScopeOption>('Selected chart module');
+  const [chartTypes, setChartTypes] = useState<string[]>(['Line Chart']);
+  const [includeSampleData, setIncludeSampleData] = useState(true);
+  const [includeNavigation, setIncludeNavigation] = useState(false);
+  const [extraRequirements, setExtraRequirements] = useState('');
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [siteOrigin, setSiteOrigin] = useState('');
+  const isUmbrellaScope = scope === 'Charts umbrella (all modules)';
+
+  useEffect(() => {
+    if (!isUmbrellaScope) {
+      return;
+    }
+    setChartTypes([...CHART_OPTIONS]);
+  }, [isUmbrellaScope]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    setSiteOrigin(window.location.origin);
+  }, []);
+
+  const prompt = useMemo(
+    () =>
+      buildAgentPrompt({
+        versionId,
+        siteOrigin,
+        platform,
+        scope,
+        chartTypes,
+        includeSampleData,
+        includeNavigation,
+        extraRequirements,
+      }),
+    [
+      chartTypes,
+      extraRequirements,
+      includeNavigation,
+      includeSampleData,
+      platform,
+      scope,
+      siteOrigin,
+      versionId,
+    ],
+  );
+
+  const onChartToggle = (chart: string) => {
+    if (isUmbrellaScope) {
+      return;
+    }
+    setChartTypes((current) => {
+      const next = current.includes(chart)
+        ? current.filter((item) => item !== chart)
+        : [...current, chart];
+      return next.length > 0 ? next : [chart];
+    });
+  };
+
+  const onCopy = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(prompt);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = prompt;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+
+    window.setTimeout(() => setCopyState('idle'), 1400);
+  };
+
+  return (
+    <section className="agent-builder animate-fadeIn">
+      <h1>Agent Prompt Builder</h1>
+      <p>
+        Configure what your integration agent should do, then copy the generated prompt and paste
+        it into your preferred AI assistant.
+      </p>
+
+      <div className="agent-builder__grid">
+        <div className="agent-builder__field">
+          <label htmlFor="agent-platform">Platform</label>
+          <select
+            id="agent-platform"
+            value={platform}
+            onChange={(event) => setPlatform(event.target.value as PlatformOption)}
+          >
+            {PLATFORM_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="agent-builder__field">
+          <label htmlFor="agent-scope">Scope</label>
+          <select
+            id="agent-scope"
+            value={scope}
+            onChange={(event) => setScope(event.target.value as ScopeOption)}
+          >
+            {SCOPE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+      </div>
+
+      <div className="agent-builder__field">
+        <label>Charts to include</label>
+        <div className="agent-builder__chips">
+          {CHART_OPTIONS.map((chart) => {
+            const selected = chartTypes.includes(chart);
+            return (
+              <button
+                key={chart}
+                type="button"
+                className={`agent-builder__chip ${selected ? 'agent-builder__chip--active' : ''} ${isUmbrellaScope ? 'agent-builder__chip--disabled' : ''}`}
+                onClick={() => onChartToggle(chart)}
+                aria-pressed={selected}
+                disabled={isUmbrellaScope}
+              >
+                {chart}
+              </button>
+            );
+          })}
+        </div>
+        {isUmbrellaScope ? (
+          <p className="agent-builder__hint">Umbrella includes all chart modules, so chart selection is locked.</p>
+        ) : null}
+      </div>
+
+      <div className="agent-builder__toggles">
+        <label>
+          <input
+            type="checkbox"
+            checked={includeSampleData}
+            onChange={(event) => setIncludeSampleData(event.target.checked)}
+          />
+          Include sample data
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={includeNavigation}
+            onChange={(event) => setIncludeNavigation(event.target.checked)}
+          />
+          Include navigation/screen wiring
+        </label>
+      </div>
+
+      <div className="agent-builder__field">
+        <label htmlFor="agent-extra">Extra requirements</label>
+        <textarea
+          id="agent-extra"
+          value={extraRequirements}
+          onChange={(event) => setExtraRequirements(event.target.value)}
+          placeholder="Example: optimize for small APK size and avoid unnecessary modules."
+          rows={3}
+        />
+      </div>
+
+      <div className="agent-builder__prompt">
+        <div className="agent-builder__prompt-header">
+          <h2>Generated Prompt</h2>
+          <button type="button" onClick={onCopy} className="btn btn--secondary">
+            {copyState === 'copied'
+              ? 'Copied'
+              : copyState === 'failed'
+                ? 'Copy failed'
+                : 'Copy prompt'}
+          </button>
+        </div>
+        <pre>{prompt}</pre>
+      </div>
+    </section>
+  );
+}
+
+interface PromptInputs {
+  versionId: string;
+  siteOrigin: string;
+  platform: PlatformOption;
+  scope: ScopeOption;
+  chartTypes: string[];
+  includeSampleData: boolean;
+  includeNavigation: boolean;
+  extraRequirements: string;
+}
+
+function buildAgentPrompt(inputs: PromptInputs): string {
+  const {
+    versionId,
+    siteOrigin,
+    platform,
+    scope,
+    chartTypes,
+    includeSampleData,
+    includeNavigation,
+    extraRequirements,
+  } = inputs;
+
+  const scopeLine =
+    scope === 'Selected chart module'
+      ? 'Prefer scoped chart modules over umbrella dependency.'
+      : 'Use umbrella dependency and include all required modules.';
+
+  const sampleDataLine = includeSampleData
+    ? 'Include minimal sample data for first render.'
+    : 'Do not include sample data.';
+
+  const navigationLine = includeNavigation
+    ? 'Include navigation and screen wiring guidance.'
+    : 'Do not include app navigation setup.';
+
+  const extraLine = extraRequirements.trim()
+    ? `Extra requirements: ${extraRequirements.trim()}`
+    : 'Extra requirements: none';
+  const buildDocsUrl = (path: string) => (siteOrigin ? `${siteOrigin}${path}` : path);
+  const manualPath = buildDocsUrl(`/${versionId}/wiki/getting-started`);
+  const examplesPath = buildDocsUrl(`/${versionId}/wiki/examples`);
+  const apiPath = buildDocsUrl(`/${versionId}/api`);
+
+  return [
+    'You are a Charts integration agent.',
+    '',
+    'Goal:',
+    '- Help integrate Charts into an app based on the constraints below.',
+    '',
+    'Context:',
+    `- Platform: ${platform}`,
+    `- Chart types: ${chartTypes.join(', ')}`,
+    `- Scope policy: ${scopeLine}`,
+    `- Data policy: ${sampleDataLine}`,
+    `- Navigation policy: ${navigationLine}`,
+    `- ${extraLine}`,
+    '',
+    'Primary sources:',
+    `- Manual setup guide: ${manualPath}`,
+    `- Examples: ${examplesPath}`,
+    `- API reference: ${apiPath}`,
+    `- Repository: ${CHARTS_REPO_URL}`,
+  ].join('\n');
+}

--- a/docs-app/components/Sidebar.tsx
+++ b/docs-app/components/Sidebar.tsx
@@ -87,7 +87,19 @@ export function Sidebar({ navigation, version }: SidebarProps) {
     const currentPath = pathname.replace(/\/$/, '');
     const normalizedPath = (itemPath ?? '').replace(/\/$/, '');
 
-    return normalizedPath === currentPath && !!itemHash && hash === `#${itemHash}`;
+    if (normalizedPath !== currentPath) {
+      return false;
+    }
+
+    if (!itemHash) {
+      return true;
+    }
+
+    return hash === `#${itemHash}`;
+  }
+
+  function hasActiveChild(item: NavItem): boolean {
+    return (item.children ?? []).some((child) => isChildActive(child));
   }
 
   function closeMobileNavigation() {
@@ -148,7 +160,7 @@ export function Sidebar({ navigation, version }: SidebarProps) {
                     ) : null}
                   </span>
                 </Link>
-                {item.children && item.children.length > 0 && isActive(item) && (
+                {item.children && item.children.length > 0 && (isActive(item) || hasActiveChild(item)) && (
                   <div className="docs-sidebar__subnav">
                     {item.children.map((child) => (
                       <Link

--- a/docs-app/lib/content.ts
+++ b/docs-app/lib/content.ts
@@ -363,6 +363,21 @@ export function getNavigation(versionId: string): NavItem[] {
         }
       }
 
+      if (slug === 'getting-started') {
+        navItem.children = [
+          {
+            title: 'Manual',
+            slug: 'manual',
+            path: pagePath,
+          },
+          {
+            title: 'Agent',
+            slug: 'agent',
+            path: `/${versionId}/agent`,
+          },
+        ];
+      }
+
       if (slug === 'migration' && (markdownContent || hasBreakingChanges)) {
         const baseMigrationMarkdown = markdownContent || getDefaultMigrationPageMarkdown();
         const markdownWithBreakingChanges = versionBreakingChangesMarkdown


### PR DESCRIPTION
## Summary
- add a versioned /\[version\]/agent page with an interactive Agent Prompt Builder
- add styles for the builder UI in global docs styles
- add a Getting Started sub-navigation entry for Manual/Agent and sidebar child-active behavior

## Validation
- npm run build (docs-app)