### PR TITLE
docs: rename getting-started heading to Manual Setup

### DIFF
--- a/content/2.0.0/wiki/getting-started.md
+++ b/content/2.0.0/wiki/getting-started.md
@@ -1,5 +1,8 @@
+---
+title: Setup
+---
 
-# Getting Started with Charts
+# Manual Setup
 
 This guide will help you integrate the Charts library into your Kotlin Multiplatform project.
 

--- a/content/2.0.1/wiki/getting-started.md
+++ b/content/2.0.1/wiki/getting-started.md
@@ -1,5 +1,8 @@
+---
+title: Setup
+---
 
-# Getting Started with Charts
+# Manual Setup
 
 This guide will help you integrate the Charts library into your Kotlin Multiplatform project.
 

--- a/content/2.1.0/wiki/getting-started.md
+++ b/content/2.1.0/wiki/getting-started.md
@@ -1,5 +1,8 @@
+---
+title: Setup
+---
 
-# Getting Started with Charts
+# Manual Setup
 
 This guide will help you integrate the Charts library into your Kotlin Multiplatform project.
 

--- a/content/2.2.0/wiki/getting-started.md
+++ b/content/2.2.0/wiki/getting-started.md
@@ -1,5 +1,8 @@
+---
+title: Setup
+---
 
-# Getting Started with Charts
+# Manual Setup
 
 This guide will help you integrate the Charts library into your Kotlin Multiplatform project.
 

--- a/content/snapshot/wiki/getting-started.md
+++ b/content/snapshot/wiki/getting-started.md
@@ -1,5 +1,8 @@
+---
+title: Setup
+---
 
-# Getting Started with Charts
+# Manual Setup
 
 This guide will help you integrate the Charts library into your Kotlin Multiplatform project.
 


### PR DESCRIPTION
## Summary
- rename the getting-started page H1 to Manual Setup across all published versions and snapshot
- keep sidebar/navigation label as Setup

## Files changed
- content/2.0.0/wiki/getting-started.md
- content/2.0.1/wiki/getting-started.md
- content/2.1.0/wiki/getting-started.md
- content/2.2.0/wiki/getting-started.md
- content/snapshot/wiki/getting-started.md