### PR TITLE
fix: remove redundant build step from promote-docs workflow

### DIFF
--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -64,15 +64,6 @@ jobs:
         shell: bash
         run: bash scripts/test-docs-release-links-contract.sh
 
-      - name: Build docs app
-        env:
-          DOCS_STATIC_BASE_URL: ${{ vars.DOCS_STATIC_BASE_URL }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm ci --prefix docs-app
-          npm run build --prefix docs-app
-
       - name: Create promotion pull request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
## Summary
- Remove "Build docs app" step from `promote-docs.yml` to fix `git stash pop` failure in `peter-evans/create-pull-request@v7`
- The build step generated untracked files in `docs-app/public/content/` that conflicted with the stash restore during PR branch creation
- The `docs-ci.yml` workflow already runs `npm ci` + `npm run build` on every PR, making the build step redundant

## Root Cause
The `Promote Docs` workflow was failing with:
```
fatal: cannot create directory at 'docs-app/public/content': File exists
error: could not restore untracked files from stash
```