### PR TITLE
fix: use CHARTS_WORKFLOW_TOKEN for PR creation

### DIFF
--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Create promotion pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.CHARTS_WORKFLOW_TOKEN }}
           branch: chore/promote-docs-${{ github.event.inputs.release_version }}
           delete-branch: true
           commit-message: "chore(docs): promote snapshot to ${{ github.event.inputs.release_version }}"


### PR DESCRIPTION
## Summary
- Pass `CHARTS_WORKFLOW_TOKEN` to `peter-evans/create-pull-request` instead of relying on the default `GITHUB_TOKEN`
- Fixes: "GitHub Actions is not permitted to create or approve pull requests"

## Note
`CHARTS_WORKFLOW_TOKEN` must be added as a repository secret in `HDCharts/charts-docs` Settings → Secrets and variables → Actions with the same PAT value used in `HDCharts/charts`.