### PR TITLE
fix: capture snapshot changeset deletions in promotion PR

### DIFF
--- a/.github/workflows/promote-docs.yml
+++ b/.github/workflows/promote-docs.yml
@@ -73,9 +73,8 @@ jobs:
           commit-message: "chore(docs): promote snapshot to ${{ github.event.inputs.release_version }}"
           title: "chore(docs): promote snapshot to ${{ github.event.inputs.release_version }}"
           add-paths: |
-            content/snapshot/**
-            content/${{ github.event.inputs.release_version }}/**
-            registry/versions.json
+            content
+            registry
           body: |
             Promotes `content/snapshot` to `content/${{ github.event.inputs.release_version }}` and updates `registry/versions.json`.
 


### PR DESCRIPTION
## Summary
- Broaden `add-paths` from specific file globs to `content` and `registry` directories
- Ensures changeset file deletions from `content/snapshot/changes/` are staged in the promotion PR
- Previously, `add-paths` with `content/snapshot/**` and `content/{version}/**` could miss deletions of tracked files in snapshot