### PR TITLE
docs(snapshot): sync charts release notes

### DIFF
--- a/release-notes/2.3.0/changes/363-api-compatibility-checks.md
+++ b/release-notes/2.3.0/changes/363-api-compatibility-checks.md
@@ -1,6 +1,0 @@
-# PR Changeset
-
-- type: `feature`
-- module: `charts-core`
-- pr: `https://github.com/HDCharts/charts/pull/363`
-- release_note: `Added automated API compatibility checks to help prevent accidental breaking changes in future releases.`

--- a/release-notes/2.3.0/changes/413-add-histogram-chart.md
+++ b/release-notes/2.3.0/changes/413-add-histogram-chart.md
@@ -3,4 +3,4 @@
 - type: `feature`
 - module: `charts-histogram`
 - pr: `https://github.com/HDCharts/charts/pull/413`
-- release_note: `Add a new histogram chart with customizable styling, selection, and demos across app, docs, and playground.`
+- release_note: `Adds a new histogram chart with customizable styling, selection, and demos across app, docs, and playground.`

--- a/release-notes/2.3.0/changes/443-release-notes-sync.md
+++ b/release-notes/2.3.0/changes/443-release-notes-sync.md
@@ -1,6 +1,0 @@
-# PR Changeset
-
-- type: `docs`
-- module: `charts`
-- pr: `https://github.com/HDCharts/charts/pull/443`
-- release_note: `Release notes and migration guidance now sync through the new release workflow.`

--- a/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
+++ b/release-notes/2.3.0/migrations/394-chart-aspect-ratio-toggle.md
@@ -1,5 +1,9 @@
 ## charts-core
 
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.ChartViewDefaults.style(...)`
+
 ### Do I need to update call sites?
 
 - No, if you already call `ChartViewDefaults.style(...)` and keep the default square chart area.
@@ -24,6 +28,10 @@ val chartViewStyle = ChartViewDefaults.style(
 - Recommended: Prefer named arguments when calling style factory functions.
 
 ## charts-pie
+
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.PieChartDefaults.style(...)`
 
 ### Do I need to update call sites?
 

--- a/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
+++ b/release-notes/2.3.0/migrations/406-bar-chart-per-bar-colors.md
@@ -1,5 +1,10 @@
 ## charts-bar
 
+### Reported API symbols
+
+- `io.github.dautovicharis.charts.style.BarChartDefaults.style(...)`
+- `io.github.dautovicharis.charts.internal.BarValidationKt.validateBarData(...)`
+
 ### Do I need to update call sites?
 
 - No, if you call `BarChartDefaults.style(...)` with named arguments only.


### PR DESCRIPTION
Mirrors versioned changesets and migration fragments from the charts repository.

Source:
- release: `2.3.0`
- charts commit: `c8d6d20482139b087066ecea7f9302de83159675`
- workflow run: https://github.com/HDCharts/charts/actions/runs/30161837478