### PR TITLE
docs: restore wiki getting started sections

### DIFF
--- a/content/2.3.0/wiki/index.md
+++ b/content/2.3.0/wiki/index.md
@@ -8,9 +8,6 @@
 
 ## What's New in {{versionLabel}}
 
+## Getting Started
 
-## Breaking Changes / Migration
-
-Breaking changes and call-site migration details now live on a dedicated page:
-
-- [Migration Guide](/{{version}}/wiki/migration)
+New to Charts? Check out our [Getting Started Guide](/{{version}}/wiki/getting-started) to learn how to integrate the library into your project and create your first charts in minutes.

--- a/content/snapshot/wiki/index.md
+++ b/content/snapshot/wiki/index.md
@@ -8,6 +8,10 @@
 
 ## What's New in {{versionLabel}}
 
+## Getting Started
+
+New to Charts? Check out our [Getting Started Guide](/{{version}}/wiki/getting-started) to learn how to integrate the library into your project and create your first charts in minutes.
+
 
 ## Breaking Changes / Migration
 


### PR DESCRIPTION
## Why

The 2.3.0 landing page omitted the getting-started link, and snapshot had the same omission that would affect future promotions.

## Summary

Restores the Getting Started section for the current 2.3.0 release and adds it to snapshot so future promoted releases retain the link. The obsolete migration callout is removed from the 2.3.0 landing page.

## Changes

- Add version-aware Getting Started links to the 2.3.0 and snapshot wiki landing pages.
- Remove the 2.3.0 migration callout.

## Release/Changeset

- Not applicable (non-charts repository)

## Notes/Risk

- Low risk: documentation-only change.