### PR TITLE
feat(docs): add metadata page

### DIFF
--- a/docs-app/app/[version]/metadata/page.tsx
+++ b/docs-app/app/[version]/metadata/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { MetadataPanel } from '@/components/MetadataPanel';
+import { getAllVersions, getVersion } from '@/lib/versions';
+
+interface MetadataPageProps {
+  params: Promise<{ version: string }>;
+}
+
+export async function generateMetadata({ params }: MetadataPageProps): Promise<Metadata> {
+  const { version } = await params;
+  return {
+    title: `Metadata | Charts ${version}`,
+    description: `Build and publication metadata for Charts ${version}`,
+  };
+}
+
+export default async function MetadataPage({ params }: MetadataPageProps) {
+  const { version: versionId } = await params;
+  const version = getVersion(versionId);
+
+  if (!version) {
+    notFound();
+  }
+
+  return <MetadataPanel version={version} />;
+}
+
+export function generateStaticParams() {
+  return getAllVersions().map((version) => ({ version: version.id }));
+}

--- a/docs-app/components/Header.tsx
+++ b/docs-app/components/Header.tsx
@@ -1,13 +1,41 @@
+'use client';
+
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { VersionSwitcher } from './VersionSwitcher';
 import { DocVersion } from '@/lib/types';
+import { formatPublishedAt } from '@/lib/format';
 
 interface HeaderProps {
   versions: DocVersion[];
   currentVersion: DocVersion;
 }
 
+interface PublicationMetadata {
+  source_sha: string;
+  charts_version: string;
+  published_at: string;
+}
+
+const CHARTS_REPO_URL = 'https://github.com/HDCharts/charts';
+
 export function Header({ versions, currentVersion }: HeaderProps) {
+  const [publication, setPublication] = useState<PublicationMetadata | null>(null);
+
+  useEffect(() => {
+    const metadataFile = currentVersion.id === 'snapshot'
+      ? 'charts-snapshot-publish.json'
+      : 'charts-release-publish.json';
+
+    fetch(`/static/_meta/${metadataFile}`, { cache: 'no-store' })
+      .then((response) => response.ok ? response.json() as Promise<PublicationMetadata> : null)
+      .then((metadata) => {
+        const matchesVersion = currentVersion.id === 'snapshot' || metadata?.charts_version === currentVersion.id;
+        setPublication(matchesVersion ? metadata : null);
+      })
+      .catch(() => setPublication(null));
+  }, [currentVersion.id]);
+
   return (
     <header className="fixed top-0 left-0 right-0 z-50 flex h-16 items-center border-b border-[var(--border-color)] bg-[var(--bg-secondary)] px-6 gap-4 lg:px-4">
       <Link 
@@ -25,26 +53,20 @@ export function Header({ versions, currentVersion }: HeaderProps) {
       </Link>
 
       <nav className="ml-auto flex items-center gap-4 min-w-0 lg:gap-4">
-        <a
-          href="https://github.com/HDCharts/charts"
-          className="flex min-h-11 items-center gap-2 text-sm font-medium text-[var(--text-secondary)] no-underline transition-colors hover:text-[var(--text-primary)]"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Charts GitHub repository"
-        >
-          <svg
-            className="h-[14px] w-[14px] shrink-0"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            focusable="false"
-          >
-            <path
-              fill="currentColor"
-              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.57 7.57 0 0 1 8 4.4c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
-            />
-          </svg>
-          <span className="hidden sm:inline">GitHub</span>
-        </a>
+        {publication && (
+          <div className="hidden flex-col items-end text-xs font-mono text-[var(--text-muted)] md:flex">
+            <a
+            href={`${CHARTS_REPO_URL}/commit/${publication.source_sha}`}
+            className="no-underline transition-colors hover:text-[var(--text-primary)]"
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Charts build ${publication.charts_version}`}
+            >
+              Build {publication.charts_version} / {publication.source_sha.slice(0, 7)}
+            </a>
+            <span>Published {formatPublishedAt(publication.published_at)}</span>
+          </div>
+        )}
         <VersionSwitcher 
           versions={versions} 
           currentVersion={currentVersion} 

--- a/docs-app/components/MetadataPanel.tsx
+++ b/docs-app/components/MetadataPanel.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { DocVersion } from '@/lib/types';
+import { getVersionApiIndexUrl, getVersionDemoUrl } from '@/lib/version-links';
+import { formatPublishedAt } from '@/lib/format';
+
+interface MetadataPanelProps {
+  version: DocVersion;
+}
+
+interface PublicationMetadata {
+  source_sha: string;
+  charts_version: string;
+  published_at: string;
+}
+
+const CHARTS_REPO_URL = 'https://github.com/HDCharts/charts';
+const PLAYGROUND_REPO_URL = 'https://github.com/HDCharts/charts-playground';
+const MAVEN_BASE_URL = 'https://central.sonatype.com/artifact/io.github.dautovicharis';
+const MAVEN_SNAPSHOT_BASE_URL = 'https://central.sonatype.com/repository/maven-snapshots/io/github/dautovicharis';
+const MAVEN_SNAPSHOT_CHARTS_METADATA_URL = `${MAVEN_SNAPSHOT_BASE_URL}/charts/maven-metadata.xml`;
+const MAVEN_SNAPSHOT_BOM_METADATA_URL = `${MAVEN_SNAPSHOT_BASE_URL}/charts-bom/maven-metadata.xml`;
+const ANDROID_RELEASE_APK_URL = '/static/android/release/hdcharts-release.apk';
+const ANDROID_SNAPSHOT_APK_URL = '/static/android/snapshot/hdcharts-snapshot.apk';
+
+export function MetadataPanel({ version }: MetadataPanelProps) {
+  const [releaseMetadata, setReleaseMetadata] = useState<PublicationMetadata | null>(null);
+  const [snapshotMetadata, setSnapshotMetadata] = useState<PublicationMetadata | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/static/_meta/charts-release-publish.json', { cache: 'no-store' }),
+      fetch('/static/_meta/charts-snapshot-publish.json', { cache: 'no-store' }),
+    ])
+      .then(async ([releaseResponse, snapshotResponse]) => {
+        const release = releaseResponse.ok ? await releaseResponse.json() as PublicationMetadata : null;
+        const snapshot = snapshotResponse.ok ? await snapshotResponse.json() as PublicationMetadata : null;
+        setReleaseMetadata(release);
+        setSnapshotMetadata(snapshot);
+      })
+      .catch(() => {
+        setReleaseMetadata(null);
+        setSnapshotMetadata(null);
+      });
+  }, []);
+
+  const currentMetadata = version.id === 'snapshot'
+    ? snapshotMetadata
+    : releaseMetadata?.charts_version === version.id ? releaseMetadata : null;
+  const isSnapshot = version.id === 'snapshot';
+
+  return (
+    <div className="mx-auto max-w-[1000px] px-4 animate-fade-in">
+      <h1>Metadata</h1>
+      <p className="mb-8 max-w-[760px] text-[var(--text-secondary)]">
+        Build, publication, and artifact information for the selected Charts version, the latest snapshot, and the web playground.
+      </p>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        {isSnapshot ? (
+          <SnapshotMetadataCard metadata={snapshotMetadata} version={version} />
+        ) : (
+          <ReleaseMetadataCard metadata={currentMetadata} version={version} playgroundMetadata={snapshotMetadata} />
+        )}
+
+      </div>
+    </div>
+  );
+}
+
+function ReleaseMetadataCard({
+  metadata,
+  version,
+  playgroundMetadata,
+}: {
+  metadata: PublicationMetadata | null;
+  version: DocVersion;
+  playgroundMetadata: PublicationMetadata | null;
+}) {
+  return (
+    <ChannelMetadataCard
+      title={`Charts ${version.label}`}
+      metadata={metadata}
+      unavailableLabel="Publication metadata unavailable for this version."
+      apiUrl={getVersionApiIndexUrl(version)}
+      demoUrl={getVersionDemoUrl(version)}
+      apkUrl={ANDROID_RELEASE_APK_URL}
+      apkLabel="Download Android release APK"
+      artifactVersion={metadata?.charts_version ?? version.id}
+      isSnapshot={false}
+      playgroundMetadata={playgroundMetadata}
+    />
+  );
+}
+
+function SnapshotMetadataCard({ metadata, version }: { metadata: PublicationMetadata | null; version: DocVersion }) {
+  return (
+    <ChannelMetadataCard
+      title="Latest snapshot"
+      metadata={metadata}
+      unavailableLabel="Snapshot metadata unavailable."
+      apiUrl="/static/api/snapshot/index.html"
+      demoUrl="/demo/snapshot/"
+      apkUrl={ANDROID_SNAPSHOT_APK_URL}
+      apkLabel="Download Android snapshot APK"
+      artifactVersion={metadata?.charts_version ?? version.id}
+      isSnapshot
+      playgroundMetadata={metadata}
+    />
+  );
+}
+
+function ChannelMetadataCard({
+  title,
+  metadata,
+  unavailableLabel,
+  apiUrl,
+  demoUrl,
+  apkUrl,
+  apkLabel,
+  artifactVersion,
+  isSnapshot,
+  playgroundMetadata,
+}: {
+  title: string;
+  metadata: PublicationMetadata | null;
+  unavailableLabel: string;
+  apiUrl: string;
+  demoUrl: string;
+  apkUrl: string;
+  apkLabel: string;
+  artifactVersion: string;
+  isSnapshot: boolean;
+  playgroundMetadata: PublicationMetadata | null;
+}) {
+  return (
+    <MetadataCard title={title} className="lg:col-span-2">
+      <section>
+        <h3 className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Publication</h3>
+        <PublicationDetails metadata={metadata} unavailableLabel={unavailableLabel} />
+        <MetadataLinks>
+          <MetadataLink href={apiUrl}>API</MetadataLink>
+          <MetadataLink href={demoUrl}>Demo</MetadataLink>
+          {isSnapshot ? (
+            <MetadataLink href={MAVEN_SNAPSHOT_CHARTS_METADATA_URL}>Metadata</MetadataLink>
+          ) : (
+            <MetadataLink href={CHARTS_REPO_URL}>Source</MetadataLink>
+          )}
+        </MetadataLinks>
+        <ApkAction>
+          <ApkDownloadLink href={apkUrl} label={apkLabel} />
+        </ApkAction>
+      </section>
+      <AndroidArtifacts
+        artifactVersion={artifactVersion}
+        isSnapshot={isSnapshot}
+        mavenArtifactBaseUrl={isSnapshot ? MAVEN_SNAPSHOT_BASE_URL : MAVEN_BASE_URL}
+      />
+      <PlaygroundDetails metadata={playgroundMetadata} />
+    </MetadataCard>
+  );
+}
+
+function PlaygroundDetails({ metadata }: { metadata: PublicationMetadata | null }) {
+  return (
+    <div className="mt-5 border-t border-[var(--border-color)] pt-4">
+      <h3 className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Playground</h3>
+      <div className="space-y-2 text-sm">
+        <MetadataRow label="App">Snapshot playground</MetadataRow>
+        <MetadataRow label="Charts build">{metadata?.charts_version ?? 'Unavailable'}</MetadataRow>
+        <MetadataRow label="Published">{formatPublishedAt(metadata?.published_at)}</MetadataRow>
+        <MetadataLinks>
+          <MetadataLink href="/playground/snapshot/">Playground</MetadataLink>
+          <MetadataLink href={PLAYGROUND_REPO_URL}>Source</MetadataLink>
+        </MetadataLinks>
+      </div>
+    </div>
+  );
+}
+
+function MetadataCard({ title, children, className = '' }: { title: string; children: React.ReactNode; className?: string }) {
+  return (
+    <section className={`rounded-xl border border-[var(--border-color)] bg-[var(--bg-secondary)] p-5 ${className}`}>
+      <h2 className="mt-0 mb-4 text-xl font-semibold text-[var(--text-primary)]">{title}</h2>
+      <div className="space-y-2 text-sm">{children}</div>
+    </section>
+  );
+}
+
+function PublicationDetails({ metadata, unavailableLabel }: { metadata: PublicationMetadata | null; unavailableLabel: string }) {
+  if (!metadata) {
+    return <p className="text-sm text-[var(--text-muted)]">{unavailableLabel}</p>;
+  }
+
+  return (
+    <>
+      <MetadataRow label="Charts version">{metadata.charts_version}</MetadataRow>
+      <MetadataRow label="Published">{formatPublishedAt(metadata.published_at)}</MetadataRow>
+      <MetadataRow label="Source">
+        <a href={`${CHARTS_REPO_URL}/commit/${metadata.source_sha}`} target="_blank" rel="noopener noreferrer" className="font-mono text-[var(--link-color)] hover:text-[var(--link-color-hover)]">
+          {metadata.source_sha.slice(0, 12)}
+        </a>
+      </MetadataRow>
+    </>
+  );
+}
+
+function MetadataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid gap-1 sm:grid-cols-[130px_1fr] sm:items-baseline">
+      <dt className="text-[var(--text-muted)]">{label}</dt>
+      <dd className="break-words text-[var(--text-primary)]">{children}</dd>
+    </div>
+  );
+}
+
+function MetadataLinks({ children }: { children: React.ReactNode }) {
+  return <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 border-t border-[var(--border-color)] pt-3">{children}</div>;
+}
+
+function AndroidArtifacts({
+  artifactVersion,
+  isSnapshot,
+  mavenArtifactBaseUrl,
+}: {
+  artifactVersion: string;
+  isSnapshot: boolean;
+  mavenArtifactBaseUrl: string;
+}) {
+  return (
+    <div className="mt-5 border-t border-[var(--border-color)] pt-4">
+      <h3 className="mb-3 text-sm font-semibold text-[var(--text-primary)]">Android and multiplatform artifacts</h3>
+      <div className="space-y-2 text-sm">
+        <MetadataRow label="Platforms">Android, iOS, Desktop, Web</MetadataRow>
+        <MetadataRow label="Group">io.github.dautovicharis</MetadataRow>
+        <MetadataRow label="Main artifact">
+          <code>io.github.dautovicharis:charts:{artifactVersion}</code>
+        </MetadataRow>
+        <MetadataRow label="BOM artifact">
+          <code>io.github.dautovicharis:charts-bom:{artifactVersion}</code>
+        </MetadataRow>
+        <MetadataLinks>
+          <MetadataLink href={isSnapshot ? MAVEN_SNAPSHOT_CHARTS_METADATA_URL : `${mavenArtifactBaseUrl}/charts/overview`}>
+            Metadata
+          </MetadataLink>
+          <MetadataLink href={isSnapshot ? MAVEN_SNAPSHOT_BOM_METADATA_URL : `${mavenArtifactBaseUrl}/charts-bom/overview`}>
+            BOM metadata
+          </MetadataLink>
+        </MetadataLinks>
+      </div>
+    </div>
+  );
+}
+
+function MetadataLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return <a href={href} target="_blank" rel="noopener noreferrer" className="text-[var(--link-color)] underline decoration-[0.08em] underline-offset-[0.12em] hover:text-[var(--link-color-hover)]">{children}</a>;
+}
+
+function ApkDownloadLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      download
+      className="inline-flex items-center gap-2 rounded-md border border-[var(--color-warning)] bg-[color-mix(in_oklch,var(--color-warning)_18%,var(--bg-secondary))] px-3 py-2 font-semibold text-[var(--text-primary)] no-underline transition-colors hover:bg-[color-mix(in_oklch,var(--color-warning)_28%,var(--bg-secondary))]"
+    >
+      <svg className="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M8 2v8m0 0 3-3m-3 3L5 7M3 13.5h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      {label}
+    </a>
+  );
+}
+
+function ApkAction({ children }: { children: React.ReactNode }) {
+  return <div className="mt-5 border-t border-[var(--border-color)] pt-4">{children}</div>;
+}

--- a/docs-app/components/Sidebar.tsx
+++ b/docs-app/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ExternalLinkIcon,
   GettingStartedIcon,
   MigrationIcon,
+  MetadataIcon,
   OverviewIcon,
   PlaygroundIcon,
   ThanksIcon,
@@ -295,6 +296,26 @@ export function Sidebar({ navigation, version }: SidebarProps) {
                 <ThanksIcon />
               </span>
               <span className="flex items-center gap-2">Thanks</span>
+            </Link>
+          </nav>
+        </div>
+
+        <div className="mb-6 lg:mb-5 last:mb-0">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)]">Metadata</h2>
+          <nav className="flex flex-col gap-1" aria-label="Metadata">
+            <Link
+              href={`/${version.id}/metadata`}
+              className={cn(
+                "flex min-h-11 items-center gap-2 border-l-2 border-transparent px-3 py-2 text-sm text-[var(--text-secondary)] no-underline transition-colors",
+                "hover:bg-transparent hover:text-[var(--text-primary)]",
+                pathname.includes('/metadata') && "border-l-[var(--color-primary)] bg-transparent text-[var(--text-primary)] font-medium"
+              )}
+              onClick={closeMobileNavigation}
+            >
+              <span className="h-4 w-4 shrink-0 opacity-90 [&>svg]:h-4 [&>svg]:w-4">
+                <MetadataIcon />
+              </span>
+              <span className="flex items-center gap-2">Build and release metadata</span>
             </Link>
           </nav>
         </div>

--- a/docs-app/components/icons/SidebarIcons.tsx
+++ b/docs-app/components/icons/SidebarIcons.tsx
@@ -225,6 +225,22 @@ export function ThanksIcon(props: IconProps) {
   );
 }
 
+export function MetadataIcon(props: IconProps) {
+  return (
+    <svg {...withDefaults(props)}>
+      <path
+        d="M5 5.5h14M5 12h14M5 18.5h9"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <circle cx="3.5" cy="5.5" r="1" fill="currentColor" />
+      <circle cx="3.5" cy="12" r="1" fill="currentColor" />
+      <circle cx="3.5" cy="18.5" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function ExternalLinkIcon(props: IconProps) {
   return (
     <svg {...withDefaults(props)}>

--- a/docs-app/components/index.ts
+++ b/docs-app/components/index.ts
@@ -2,3 +2,4 @@ export { Header } from './Header';
 export { Sidebar } from './Sidebar';
 export { VersionSwitcher } from './VersionSwitcher';
 export { MarkdownRenderer } from './MarkdownRenderer';
+export { MetadataPanel } from './MetadataPanel';

--- a/docs-app/lib/format.ts
+++ b/docs-app/lib/format.ts
@@ -1,0 +1,36 @@
+export function formatPublishedAt(value?: string): string {
+  if (!value) {
+    return 'Unavailable';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const absolute = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+  const differenceInSeconds = (date.getTime() - Date.now()) / 1000;
+  const absoluteDifferenceInSeconds = Math.abs(differenceInSeconds);
+
+  let divisor = 1;
+  let unit: Intl.RelativeTimeFormatUnit = 'second';
+  if (absoluteDifferenceInSeconds >= 86400) {
+    divisor = 86400;
+    unit = 'day';
+  } else if (absoluteDifferenceInSeconds >= 3600) {
+    divisor = 3600;
+    unit = 'hour';
+  } else if (absoluteDifferenceInSeconds >= 60) {
+    divisor = 60;
+    unit = 'minute';
+  }
+
+  const relative = new Intl.RelativeTimeFormat(undefined, { numeric: 'always' }).format(
+    Math.round(differenceInSeconds / divisor),
+    unit,
+  );
+  return `${absolute} (${relative})`;
+}

--- a/scripts/test-docs-release-links-contract.sh
+++ b/scripts/test-docs-release-links-contract.sh
@@ -13,6 +13,7 @@ REGISTRY_PATH="${REPO_ROOT}/registry/versions.json"
 NEXT_CONFIG_PATH="${REPO_ROOT}/docs-app/next.config.ts"
 SIDEBAR_PATH="${REPO_ROOT}/docs-app/components/Sidebar.tsx"
 API_PAGE_PATH="${REPO_ROOT}/docs-app/app/[version]/api/page.tsx"
+METADATA_PAGE_PATH="${REPO_ROOT}/docs-app/app/[version]/metadata/page.tsx"
 
 failures=0
 
@@ -126,6 +127,8 @@ test_user_facing_links_use_clean_paths() {
   assert_file_contains "${SIDEBAR_PATH}" 'const demoUrl = getVersionDemoUrl(version);' "sidebar uses version demoBase helper"
   assert_file_contains "${SIDEBAR_PATH}" 'href="/playground"' "sidebar playground link uses clean URL"
   assert_file_contains "${API_PAGE_PATH}" 'const apiUrl = getVersionApiIndexUrl(version);' "api page uses version apiBase helper"
+  assert_file_exists "${METADATA_PAGE_PATH}" "metadata page exists"
+  assert_file_contains "${SIDEBAR_PATH}" 'href={`/${version.id}/metadata`}' "sidebar metadata link uses version path"
 }
 
 main() {


### PR DESCRIPTION
## Why

Add a dedicated metadata page so docs can show build, publication, artifact, and playground release details in one place.

## Summary

This introduces a new metadata route, panel, and shared formatting helpers, plus sidebar/header navigation updates and contract checks for the docs app.

## Changes

- Add a new /{version}/metadata page and metadata panel
- Surface build/publication details in the header and sidebar
- Add release-link contract coverage and shared date formatting

## Release/Changeset

- Not applicable (non-charts repository)

## Notes/Risk

- None
