### PR TITLE
chore(release): update manifest schema

### DIFF
--- a/docs-app/public/release-manifest.json
+++ b/docs-app/public/release-manifest.json
@@ -1,1 +1,1 @@
-{"releaseVersion":"2.3.0","chartsCommit":"1c858d916f9aed1a9475ccde09949c708ba23c88","deployedAt":"2026-07-26T13:58:34Z"}
+{"source_sha":"1c858d916f9aed1a9475ccde09949c708ba23c88","charts_version":"2.3.0","published_at":"2026-07-26T13:58:34Z"}


### PR DESCRIPTION
## Why

The release manifest schema now uses the shared publication provenance field names.

## Summary

Update the committed 2.3.0 manifest to match the schema consumed by the current release workflow and docs app.

## Changes

- Rename the legacy manifest fields to source_sha, charts_version, and published_at.

## Release/Changeset

- Not applicable (non-charts repository)

## Notes/Risk

- This is a coordinated companion to HDCharts/charts#481.