### PR TITLE
docs(thanks): add missing attributions and fix outdated credits

### DIFF
--- a/docs-app/app/thanks/data/charts-docs.json
+++ b/docs-app/app/thanks/data/charts-docs.json
@@ -23,6 +23,12 @@
           "description": "Typed superset of JavaScript that compiles to plain JavaScript.",
           "url": "https://www.typescriptlang.org/",
           "license": "Apache-2.0"
+        },
+        {
+          "name": "Tailwind CSS",
+          "description": "Utility-first CSS framework used for styling the documentation site.",
+          "url": "https://github.com/tailwindlabs/tailwindcss",
+          "license": "MIT"
         }
       ]
     },

--- a/docs-app/app/thanks/data/charts-gif-recorder.json
+++ b/docs-app/app/thanks/data/charts-gif-recorder.json
@@ -78,6 +78,12 @@
           "description": "Kotlin linter and formatter with built-in rules.",
           "url": "https://github.com/pinterest/ktlint",
           "license": "MIT"
+        },
+        {
+          "name": "Axion Release",
+          "description": "Gradle plugin that derives project versions from Git tags.",
+          "url": "https://github.com/allegro/axion-release-plugin",
+          "license": "Apache-2.0"
         }
       ]
     },

--- a/docs-app/app/thanks/data/charts-playground.json
+++ b/docs-app/app/thanks/data/charts-playground.json
@@ -22,21 +22,21 @@
       "title": "Libraries",
       "items": [
         {
-          "name": "Ktor",
-          "description": "Asynchronous HTTP client and server framework for Kotlin.",
-          "url": "https://ktor.io/",
-          "license": "Apache-2.0"
-        },
-        {
           "name": "AndroidX Lifecycle",
           "description": "Lifecycle-aware components for managing Android lifecycle.",
           "url": "https://developer.android.com/jetpack/androidx/releases/lifecycle",
           "license": "Apache-2.0"
         },
         {
-          "name": "KotlinX Serialization",
-          "description": "Kotlin multi-format serialization library.",
-          "url": "https://github.com/Kotlin/kotlinx.serialization",
+          "name": "KotlinX DateTime",
+          "description": "Multiplatform date and time library for Kotlin.",
+          "url": "https://github.com/Kotlin/kotlinx-datetime",
+          "license": "Apache-2.0"
+        },
+        {
+          "name": "Kotlin Compiler (Embeddable)",
+          "description": "Embeddable Kotlin compiler used to compile and run playground code snippets.",
+          "url": "https://github.com/JetBrains/kotlin",
           "license": "Apache-2.0"
         }
       ]

--- a/docs-app/app/thanks/data/charts.json
+++ b/docs-app/app/thanks/data/charts.json
@@ -22,21 +22,9 @@
       "title": "Libraries",
       "items": [
         {
-          "name": "KotlinX Coroutines",
-          "description": "Library for writing asynchronous code using coroutines.",
-          "url": "https://github.com/Kotlin/kotlinx.coroutines",
-          "license": "Apache-2.0"
-        },
-        {
           "name": "KotlinX Immutable Collections",
           "description": "Persistent immutable collection implementations for Kotlin.",
           "url": "https://github.com/Kotlin/kotlinx.collections.immutable",
-          "license": "Apache-2.0"
-        },
-        {
-          "name": "Koin",
-          "description": "Lightweight dependency injection framework for Kotlin.",
-          "url": "https://insert-koin.io/",
           "license": "Apache-2.0"
         }
       ]
@@ -72,6 +60,18 @@
           "name": "Gradle japicmp Plugin",
           "description": "Binary/source API compatibility checks used in release and CI workflows.",
           "url": "https://github.com/melix/japicmp-gradle-plugin",
+          "license": "Apache-2.0"
+        },
+        {
+          "name": "KSP (Kotlin Symbol Processing)",
+          "description": "Kotlin code-generation API used by build tooling and annotation processors.",
+          "url": "https://github.com/google/ksp",
+          "license": "Apache-2.0"
+        },
+        {
+          "name": "Axion Release",
+          "description": "Gradle plugin that derives project versions from Git tags.",
+          "url": "https://github.com/allegro/axion-release-plugin",
           "license": "Apache-2.0"
         }
       ]


### PR DESCRIPTION
## Summary
Audit of the Thanks ("Built With") page against actual declared/applied dependencies across the HDCharts repos.

- **charts**: add `KSP` and `Axion Release`; remove `Koin` and `KotlinX Coroutines` (demo-only deps, already credited under `charts-demo`).
- **charts-gif-recorder**: add `Axion Release`.
- **charts-playground**: replace stale `Ktor` and `KotlinX Serialization` credits (not actual dependencies) with `KotlinX DateTime` and `Kotlin Compiler (Embeddable)`.
- **charts-docs**: add `Tailwind CSS`.