### PR TITLE
fix(docs): redirect legacy documentation URLs

### DIFF
--- a/docs-app/next.config.ts
+++ b/docs-app/next.config.ts
@@ -120,6 +120,59 @@ const nextConfig: NextConfig = {
   // Redirects for convenience
   async redirects() {
     return [
+      // Legacy static-content URLs previously exposed the Markdown source.
+      {
+        source: "/content/:version/wiki",
+        destination: "/:version/wiki",
+        permanent: true,
+      },
+      {
+        source: "/content/:version/wiki/",
+        destination: "/:version/wiki",
+        permanent: true,
+      },
+      // Legacy API directory URLs previously exposed a forbidden static directory.
+      {
+        source: "/static/api/:version",
+        destination: "/:version/api",
+        permanent: true,
+      },
+      {
+        source: "/static/api/:version/",
+        destination: "/:version/api",
+        permanent: true,
+      },
+      // Legacy docs-prefixed URLs from the previous Charts deployment.
+      {
+        source: "/docs/content/:version/wiki",
+        destination: "/:version/wiki",
+        permanent: true,
+      },
+      {
+        source: "/docs/content/:version/wiki/",
+        destination: "/:version/wiki",
+        permanent: true,
+      },
+      {
+        source: "/docs/static/api/:version",
+        destination: "/:version/api",
+        permanent: true,
+      },
+      {
+        source: "/docs/static/api/:version/",
+        destination: "/:version/api",
+        permanent: true,
+      },
+      {
+        source: "/docs/static/demo/:version",
+        destination: "/demo/:version/",
+        permanent: true,
+      },
+      {
+        source: "/docs/static/demo/:version/",
+        destination: "/demo/:version/",
+        permanent: true,
+      },
       {
         source: "/demo",
         destination: `/demo/${defaultDocsVersion}/`,


### PR DESCRIPTION
## Summary

- Redirect legacy `/content/:version/wiki` URLs to the versioned wiki pages.
- Redirect legacy `/static/api/:version` URLs to the versioned API pages.
- Redirect old `/docs/...` content, API, and demo URLs to their current routes.

## Validation

- `npm exec -- tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Verified legacy routes return permanent redirects locally.