### PR TITLE
docs: stop recommending direct charts-core usage

### DIFF
--- a/content/2.2.0/wiki/getting-started.md
+++ b/content/2.2.0/wiki/getting-started.md
@@ -35,8 +35,6 @@ commonMain.dependencies {
     implementation("io.github.dautovicharis:charts-stacked-bar:<version>")
     implementation("io.github.dautovicharis:charts-stacked-area:<version>")
     implementation("io.github.dautovicharis:charts-radar:<version>")
-    // Optional: add charts-core directly only if you need shared base APIs
-    implementation("io.github.dautovicharis:charts-core:<version>")
 }
 ```
 

--- a/content/2.2.0/wiki/index.md
+++ b/content/2.2.0/wiki/index.md
@@ -26,7 +26,6 @@ implementation("io.github.dautovicharis:charts:<version>")
 Use modular artifacts (pick what you need):
 
 ```kotlin
-implementation("io.github.dautovicharis:charts-core:<version>")
 implementation("io.github.dautovicharis:charts-line:<version>")
 implementation("io.github.dautovicharis:charts-pie:<version>")
 implementation("io.github.dautovicharis:charts-bar:<version>")
@@ -39,7 +38,6 @@ Use BOM for aligned versions (where Gradle platforms are supported):
 
 ```kotlin
 implementation(platform("io.github.dautovicharis:charts-bom:<version>"))
-implementation("io.github.dautovicharis:charts-core")
 implementation("io.github.dautovicharis:charts-line")
 implementation("io.github.dautovicharis:charts-pie")
 implementation("io.github.dautovicharis:charts-bar")

--- a/content/2.3.0/wiki/getting-started.md
+++ b/content/2.3.0/wiki/getting-started.md
@@ -36,8 +36,6 @@ commonMain.dependencies {
     implementation("io.github.dautovicharis:charts-stacked-bar:<version>")
     implementation("io.github.dautovicharis:charts-stacked-area:<version>")
     implementation("io.github.dautovicharis:charts-radar:<version>")
-    // Optional: add charts-core directly only if you need shared base APIs
-    implementation("io.github.dautovicharis:charts-core:<version>")
 }
 ```
 

--- a/content/2.4.0/wiki/getting-started.md
+++ b/content/2.4.0/wiki/getting-started.md
@@ -36,8 +36,6 @@ commonMain.dependencies {
     implementation("io.github.dautovicharis:charts-stacked-bar:<version>")
     implementation("io.github.dautovicharis:charts-stacked-area:<version>")
     implementation("io.github.dautovicharis:charts-radar:<version>")
-    // Optional: add charts-core directly only if you need shared base APIs
-    implementation("io.github.dautovicharis:charts-core:<version>")
 }
 ```
 

--- a/content/snapshot/wiki/getting-started.md
+++ b/content/snapshot/wiki/getting-started.md
@@ -36,8 +36,6 @@ commonMain.dependencies {
     implementation("io.github.dautovicharis:charts-stacked-bar:<version>")
     implementation("io.github.dautovicharis:charts-stacked-area:<version>")
     implementation("io.github.dautovicharis:charts-radar:<version>")
-    // Optional: add charts-core directly only if you need shared base APIs
-    implementation("io.github.dautovicharis:charts-core:<version>")
 }
 ```
 


### PR DESCRIPTION
Remove direct charts-core dependency examples from the versioned and snapshot getting-started documentation. BOM guidance and historical migration notes remain unchanged.